### PR TITLE
Bruk Texas for å hente og validere tokens

### DIFF
--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: hag-admin
   namespace: helsearbeidsgiver
+  annotations:
+    texas.nais.io/enabled: "true"
 spec:
   azure:
     application:

--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ Application.kt
 
 Auth er disablet lokalt og i dev-miljøet. (configureSecurity(disabled = Env.isTest()))
 (Dev bruker trygdeetaten-tenant, så krever trygdeetaten-bruker med medlemskap i HAG-gruppa for å enables)
-
-Hvis ønskelig, kan man enable sikkerhet lokalt og starte mock-oauth2-server fra docker-compose fil i src/test/resources og deretter hente token og sende med hvert kall, men på MacOS må da hostname i Env: wellKnownUrl og tokenEndpointUrl endres til host.docker.internal (localhost aksepteres ikke av token-support når app starter)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ val mockk_version: String by project
 
 plugins {
     kotlin("jvm") version "2.0.20"
+    kotlin("plugin.serialization") version "2.0.20"
     id("io.ktor.plugin") version "2.3.12"
 }
 
@@ -30,19 +31,23 @@ repositories {
 }
 
 dependencies {
-    implementation("no.nav.helsearbeidsgiver:arbeidsgiver-notifikasjon-klient:3.3.3")
-    implementation("no.nav.helsearbeidsgiver:tokenprovider:0.4.0")
-    implementation("no.nav.security:token-validation-ktor-v2:5.0.5")
-    implementation("io.ktor:ktor-server-core-jvm")
+    implementation ("net.logstash.logback:logstash-logback-encoder:8.0")
+    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("io.ktor:ktor-client-apache5")
+    implementation("io.ktor:ktor-client-content-negotiation")
+    implementation("io.ktor:ktor-client-core")
+    implementation("io.ktor:ktor-serialization-kotlinx-json")
     implementation("io.ktor:ktor-server-auth-jvm")
     implementation("io.ktor:ktor-server-auth-jwt-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation("io.ktor:ktor-server-core-jvm")
     implementation("io.ktor:ktor-server-html-builder")
+    implementation("io.ktor:ktor-server-netty-jvm")
+    implementation("no.nav.helsearbeidsgiver:arbeidsgiver-notifikasjon-klient:3.3.3")
+    implementation("no.nav.helsearbeidsgiver:utils:0.9.0")
     implementation("org.jetbrains.kotlin-wrappers:kotlin-css:1.0.0-pre.817")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation ("net.logstash.logback:logstash-logback-encoder:8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+
     testImplementation("io.ktor:ktor-server-test-host-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
-    testImplementation("no.nav.security:mock-oauth2-server:2.1.9")
     testImplementation("io.mockk:mockk:$mockk_version")
 }

--- a/src/main/kotlin/no/nav/hag/Application.kt
+++ b/src/main/kotlin/no/nav/hag/Application.kt
@@ -6,7 +6,6 @@ import io.ktor.server.netty.Netty
 import no.nav.hag.plugins.configureRouting
 import no.nav.hag.plugins.configureSecurity
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
-import no.nav.helsearbeidsgiver.tokenprovider.oauth2ClientCredentialsTokenGetter
 import org.slf4j.LoggerFactory
 
 fun main() {
@@ -17,19 +16,18 @@ fun main() {
 fun Application.module() {
     val logger = LoggerFactory.getLogger(Application::class.java)
     val isTestMode = Env.isTest()
+    val authClient = AuthClient()
+
     logger.info("Started App - testmode = $isTestMode")
-    configureSecurity(disabled = isTestMode)
+
+    configureSecurity(authClient, disabled = isTestMode)
+
+    val tokenGetter = authClient.tokenGetter(Env.agNotifikasjonScope)
+    val agNotifikasjonKlient = ArbeidsgiverNotifikasjonKlient(Env.agNotifikasjonUrl, tokenGetter)
 
     val service = when {
         Env.isLocal() -> FakeServiceImpl()
-        else -> NotifikasjonServiceImpl(buildNotifikasjonKlient())
+        else -> NotifikasjonServiceImpl(agNotifikasjonKlient)
     }
     configureRouting(service)
 }
-
-private fun buildNotifikasjonKlient(): ArbeidsgiverNotifikasjonKlient {
-    val tokenGetter = oauth2ClientCredentialsTokenGetter(Env.oauth2Environment)
-    return ArbeidsgiverNotifikasjonKlient(Env.notifikasjonUrl, tokenGetter)
-}
-
-

--- a/src/main/kotlin/no/nav/hag/AuthClient.kt
+++ b/src/main/kotlin/no/nav/hag/AuthClient.kt
@@ -1,0 +1,84 @@
+package no.nav.hag
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.forms.submitForm
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+import no.nav.helsearbeidsgiver.utils.json.jsonConfig
+
+class AuthClient {
+    private val tokenEndpoint = "NAIS_TOKEN_ENDPOINT".let(System::getenv) ?: "http://localhost/mock-token"
+    private val tokenIntrospectionEndpoint =
+        "NAIS_TOKEN_INTROSPECTION_ENDPOINT".let(System::getenv) ?: "http://localhost/mock-introspection"
+
+    private val httpClient =
+        HttpClient(Apache5) {
+            expectSuccess = true
+
+            install(ContentNegotiation) {
+                json(jsonConfig)
+            }
+        }
+
+    fun tokenGetter(
+        target: String,
+    ): () -> String =
+        {
+            runBlocking {
+                httpClient
+                    .submitForm(
+                        url = tokenEndpoint,
+                        formParameters =
+                            parameters {
+                                append(Params.IDENTITY_PROVIDER, Params.Values.ENTRA_ID)
+                                append(Params.TARGET, target)
+                            },
+                    ).body<TokenResponse>()
+                    .accessToken
+            }
+        }
+
+    suspend fun introspect(
+        accessToken: String,
+    ): Boolean =
+        httpClient
+            .submitForm(
+                url = tokenIntrospectionEndpoint,
+                formParameters =
+                    parameters {
+                        append(Params.IDENTITY_PROVIDER, Params.Values.ENTRA_ID)
+                        append(Params.TOKEN, accessToken)
+                    },
+            ).body<TokenIntrospectionResponse>()
+            .active
+}
+
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+internal data class TokenResponse(
+    @JsonNames("access_token")
+    val accessToken: String,
+)
+
+@Serializable
+internal data class TokenIntrospectionResponse(
+    val active: Boolean,
+)
+
+private object Params {
+    const val IDENTITY_PROVIDER = "identity_provider"
+    const val TARGET = "target"
+    const val TOKEN = "token"
+
+    object Values {
+        // Identity provider value
+        const val ENTRA_ID = "azuread"
+    }
+}

--- a/src/main/kotlin/no/nav/hag/Env.kt
+++ b/src/main/kotlin/no/nav/hag/Env.kt
@@ -1,24 +1,16 @@
 package no.nav.hag
 
-import no.nav.helsearbeidsgiver.tokenprovider.OAuth2Environment
 object Env {
-    val clusterName = System.getenv("NAIS_CLUSTER_NAME")
-    val notifikasjonUrl = System.getenv("ARBEIDSGIVER_NOTIFIKASJON_API_URL")
-    val oauth2Environment =
-        OAuth2Environment(
-            scope = System.getenv("ARBEIDSGIVER_NOTIFIKASJON_SCOPE") ?: "dummyscope",
-            wellKnownUrl = System.getenv("AZURE_APP_WELL_KNOWN_URL") ?: "http://localhost:6666/employee/.well-known/openid-configuration",
-            tokenEndpointUrl = System.getenv("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT") ?: "http://localhost:6666/",
-            clientId = System.getenv("AZURE_APP_CLIENT_ID") ?: "123",
-            clientSecret = System.getenv("AZURE_APP_CLIENT_SECRET") ?: "123",
-            clientJwk = System.getenv("AZURE_APP_JWK") ?: "",
-        )
+    private val clusterName = System.getenv("NAIS_CLUSTER_NAME")
 
-    fun isTest() : Boolean {
+    val agNotifikasjonScope = System.getenv("ARBEIDSGIVER_NOTIFIKASJON_SCOPE") ?: "dummyscope"
+    val agNotifikasjonUrl = System.getenv("ARBEIDSGIVER_NOTIFIKASJON_API_URL")
+
+    fun isTest(): Boolean {
         return isLocal() || clusterName == "dev-gcp"
     }
 
-    fun isLocal() : Boolean {
+    fun isLocal(): Boolean {
         return clusterName == null
     }
 }

--- a/src/main/kotlin/no/nav/hag/plugins/AuthUtils.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/AuthUtils.kt
@@ -1,0 +1,10 @@
+package no.nav.hag.plugins
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.interfaces.Claim
+import io.ktor.http.auth.AuthScheme
+
+fun String?.readClaim(name: String): Claim? =
+    this?.removePrefix("${AuthScheme.Bearer} ")
+        ?.let(JWT::decode)
+        ?.getClaim(name)

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -141,11 +141,8 @@ fun Application.configureRouting(notifikasjonService: NotifikasjonService) {
 }
 
 private fun PipelineContext<Unit, ApplicationCall>.hentBrukernavnFraToken(): String {
-    val authToken =
-        call.request.authorization()?.removePrefix("${AuthScheme.Bearer} ")
-            ?: throw IllegalAccessException("Mangler autorisasjonsheader.")
-
-    return JWT().decodeJwt(authToken).claims["NAVident"]?.asString() ?: "Ukjent bruker"
+    val authToken = call.request.authorization()?.removePrefix("${AuthScheme.Bearer} ")
+    return authToken.let { JWT().decodeJwt(it) }.claims["NAVident"]?.asString() ?: "Ukjent bruker"
 }
 
 suspend inline fun ApplicationCall.respondCss(builder: CssBuilder.() -> Unit) {

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -142,7 +142,7 @@ fun Application.configureRouting(notifikasjonService: NotifikasjonService) {
 
 private fun PipelineContext<Unit, ApplicationCall>.hentBrukernavnFraToken(): String {
     val authToken = call.request.authorization()?.removePrefix("${AuthScheme.Bearer} ")
-    return authToken.let { JWT().decodeJwt(it) }.claims["NAVident"]?.asString() ?: "Ukjent bruker"
+    return authToken?.let { JWT().decodeJwt(it) }?.claims?.get("NAVident")?.asString() ?: "Ukjent bruker"
 }
 
 suspend inline fun ApplicationCall.respondCss(builder: CssBuilder.() -> Unit) {

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -1,9 +1,7 @@
 package no.nav.hag.plugins
 
-import com.auth0.jwt.JWT
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.auth.AuthScheme
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -140,10 +138,12 @@ fun Application.configureRouting(notifikasjonService: NotifikasjonService) {
     }
 }
 
-private fun PipelineContext<Unit, ApplicationCall>.hentBrukernavnFraToken(): String {
-    val authToken = call.request.authorization()?.removePrefix("${AuthScheme.Bearer} ")
-    return authToken?.let { JWT().decodeJwt(it) }?.claims?.get("NAVident")?.asString() ?: "Ukjent bruker"
-}
+private fun PipelineContext<Unit, ApplicationCall>.hentBrukernavnFraToken(): String =
+    call.request
+        .authorization()
+        .readClaim("NAVident")
+        ?.asString()
+        ?: "Ukjent bruker"
 
 suspend inline fun ApplicationCall.respondCss(builder: CssBuilder.() -> Unit) {
     this.respondText(CssBuilder().apply(builder).toString(), ContentType.Text.CSS)

--- a/src/main/kotlin/no/nav/hag/plugins/Security.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Security.kt
@@ -9,6 +9,8 @@ import io.ktor.server.auth.bearer
 import no.nav.hag.AuthClient
 import no.nav.hag.Env
 
+const val GROUP_ID_HAG = "e3ab1801-e5a6-48ca-9c3b-5a91ce182c57"
+
 fun Application.configureSecurity(authClient: AuthClient, disabled: Boolean = false) {
     if (disabled && Env.isTest()) {
         authentication {
@@ -20,7 +22,7 @@ fun Application.configureSecurity(authClient: AuthClient, disabled: Boolean = fa
         authentication {
             bearer {
                 authenticate {
-                    if (authClient.introspect(it.token)) {
+                    if (authClient.introspect(it.token) && it.token.containsClaimForAllowedGroup()) {
                         UserIdPrincipal("hag-admin")
                     } else {
                         null
@@ -30,3 +32,9 @@ fun Application.configureSecurity(authClient: AuthClient, disabled: Boolean = fa
         }
     }
 }
+
+private fun String.containsClaimForAllowedGroup(): Boolean =
+    readClaim("groups")
+        ?.asList(String::class.java)
+        .orEmpty()
+        .contains(GROUP_ID_HAG)

--- a/src/test/kotlin/no/nav/hag/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/hag/ApplicationTest.kt
@@ -10,6 +10,7 @@ import io.ktor.server.testing.testApplication
 import io.ktor.test.dispatcher.testSuspend
 import io.mockk.coEvery
 import io.mockk.mockk
+import no.nav.hag.plugins.GROUP_ID_HAG
 import no.nav.hag.plugins.configureRouting
 import no.nav.hag.plugins.configureSecurity
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
@@ -22,7 +23,9 @@ class ApplicationTest {
         val authClient = mockk<AuthClient>()
 
         val mockToken =
-            JWT.create().withClaim("NAVident", "John Ronald Reuel")
+            JWT.create()
+                .withClaim("NAVident", "John Ronald Reuel")
+                .withArrayClaim("groups", arrayOf(GROUP_ID_HAG))
                 .sign(Algorithm.HMAC256("super secret"))
 
         coEvery { authClient.introspect(mockToken) } returns true

--- a/src/test/resources/docker-compose.yaml
+++ b/src/test/resources/docker-compose.yaml
@@ -1,6 +1,0 @@
-services:
-  mock-oauth2-server:
-    image: ghcr.io/navikt/mock-oauth2-server:2.1.9
-    ports:
-      - 6666:6666
-    hostname: host.docker.internal


### PR DESCRIPTION
Blir kvitt `tokenprovider`, som er vårt eget bibliotek som snart kan arkiveres.
Fjerner også `token-support`.