### PR TITLE
forkast forespørsler i bro manuelt

### DIFF
--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -26,6 +26,8 @@ spec:
           namespace: fager
         - application: logging
           namespace: nais-system
+  kafka:
+    pool: { { kafkaPool } }
   env:
     - name: ARBEIDSGIVER_NOTIFIKASJON_API_URL
       value: "http://notifikasjon-produsent-api.fager/api/graphql"

--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -27,7 +27,7 @@ spec:
         - application: logging
           namespace: nais-system
   kafka:
-    pool: { { kafkaPool } }
+    pool: {{ kafkaPool }}
   env:
     - name: ARBEIDSGIVER_NOTIFIKASJON_API_URL
       value: "http://notifikasjon-produsent-api.fager/api/graphql"

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -1,4 +1,5 @@
 login: false
+kafkaPool: nav-dev
 env:
   - name: ARBEIDSGIVER_NOTIFIKASJON_SCOPE
     value: "api://dev-gcp.fager.notifikasjon-produsent-api/.default"

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -1,3 +1,4 @@
+kafkaPool: nav-prod
 login: true
 env:
   - name: ARBEIDSGIVER_NOTIFIKASJON_SCOPE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import kotlin.collections.forEach
 
 val kotlin_version: String by project
 val ktor_version: String by project
+val kafka_client_version: String by project
 val logback_version: String by project
 val mockk_version: String by project
 val arbeidsgiver_notifikasjon_klient_version: String by project
@@ -69,6 +70,7 @@ dependencies {
     implementation("no.nav.helsearbeidsgiver:utils:0.10.1")
     implementation("org.jetbrains.kotlin-wrappers:kotlin-css:1.0.0-pre.817")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+    implementation("org.apache.kafka:kafka-clients:$kafka_client_version")
 
     testImplementation("io.ktor:ktor-client-core:$ktor_version")
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktor_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 kotlin_version=2.2.21
 ktor_version=3.4.0
+kafka_client_version=4.1.0
 logback_version=1.5.25
 mockk_version=1.13.13
 arbeidsgiver_notifikasjon_klient_version=4.1.0

--- a/src/main/kotlin/no/nav/hag/Application.kt
+++ b/src/main/kotlin/no/nav/hag/Application.kt
@@ -68,10 +68,10 @@ fun Application.module() {
 
     val forespoerselService = ForespoerselServiceImpl(KafkaConfig.getKafkaProducer())
 
-    val service =
+    val notifikasjonService =
         when {
             Env.isLocal() -> FakeServiceImpl()
             else -> NotifikasjonServiceImpl(agNotifikasjonKlient, Env.utgaattUrl)
         }
-    configureRouting(service, appMicrometerRegistry)
+    configureRouting(notifikasjonService, forespoerselService, appMicrometerRegistry)
 }

--- a/src/main/kotlin/no/nav/hag/Application.kt
+++ b/src/main/kotlin/no/nav/hag/Application.kt
@@ -14,6 +14,7 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.serialization.json.Json
+import no.nav.hag.kafkaproducer.KafkaConfig
 import no.nav.hag.plugins.configureRouting
 import no.nav.hag.plugins.configureSecurity
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
@@ -64,6 +65,8 @@ fun Application.module() {
             getAccessToken = tokenGetter,
             sendevindu = Sendevindu.NKS_AAPNINGSTID,
         )
+
+    val forespoerselService = ForespoerselServiceImpl(KafkaConfig.getKafkaProducer())
 
     val service =
         when {

--- a/src/main/kotlin/no/nav/hag/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/hag/ForespoerselService.kt
@@ -4,6 +4,8 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.kafkaproducer.KafkaConfig.FORESPOERSEL_MANUELT_FORKASTET
+import no.nav.hag.kafkaproducer.KafkaConfig.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID
+import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_BEHOV
 import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_FORESPOERSEL_ID
 import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_NOTIS
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -20,6 +22,11 @@ interface ForespoerselService {
         foresporselId: UUID,
         brukernavn: String,
     )
+
+    suspend fun synkroniserForesporsler(
+        vedtaksperiodeId: UUID,
+        brukernavn: String,
+    )
 }
 
 class ForespoerselServiceImpl(
@@ -34,18 +41,43 @@ class ForespoerselServiceImpl(
         foresporselId: UUID,
         brukernavn: String,
     ) {
-        logger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
-        sikkerLogger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
+        "Forkaster forespørsel: $foresporselId. Utført av $brukernavn".also {
+            logger.info(it)
+            sikkerLogger.info(it)
+        }
         val kafkaMessage =
             mapOf(
                 PRI_FELT_NAVN_NOTIS to FORESPOERSEL_MANUELT_FORKASTET.toJson(),
                 PRI_FELT_NAVN_FORESPOERSEL_ID to foresporselId.toJson(),
             )
+        sendTilKafka(kafkaMessage, foresporselId)
+    }
+
+    override suspend fun synkroniserForesporsler(
+        vedtaksperiodeId: UUID,
+        brukernavn: String,
+    ) {
+        "Synkroniserer på vedtaksperiode: $vedtaksperiodeId. Utført av $brukernavn".also {
+            logger.info(it)
+            sikkerLogger.info(it)
+        }
+        val kafkaMessage =
+            mapOf(
+                PRI_FELT_NAVN_BEHOV to HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID.toJson(),
+                PRI_FELT_NAVN_FORESPOERSEL_ID to vedtaksperiodeId.toJson(),
+            )
+        sendTilKafka(kafkaMessage, vedtaksperiodeId)
+    }
+
+    private fun sendTilKafka(
+        kafkaMessage: Map<String, JsonElement>,
+        key: UUID,
+    ) {
         runCatching {
             kafkaProducer.send(
                 ProducerRecord(
                     topic,
-                    foresporselId.toString(),
+                    key.toString(),
                     kafkaMessage.toJsonStr(
                         MapSerializer(String.serializer(), JsonElement.serializer()),
                     ),
@@ -67,5 +99,12 @@ class MockForespoerselService : ForespoerselService {
         brukernavn: String,
     ) {
         logger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
+    }
+
+    override suspend fun synkroniserForesporsler(
+        vedtaksperiodeId: UUID,
+        brukernavn: String,
+    ) {
+        logger.info("Synkroniserer: $vedtaksperiodeId. Utført av $brukernavn")
     }
 }

--- a/src/main/kotlin/no/nav/hag/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/hag/ForespoerselService.kt
@@ -3,6 +3,9 @@ package no.nav.hag
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import no.nav.hag.kafkaproducer.KafkaConfig.FORESPOERSEL_MANUELT_FORKASTET
+import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_FORESPOERSEL_ID
+import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_NOTIS
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -35,8 +38,8 @@ class ForespoerselServiceImpl(
         sikkerLogger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
         val kafkaMessage =
             mapOf(
-                "notis" to "FORESPOERSEL_MANUELT_FORKASTET".toJson(),
-                "forespoerselId" to foresporselId.toJson(),
+                PRI_FELT_NAVN_NOTIS to FORESPOERSEL_MANUELT_FORKASTET.toJson(),
+                PRI_FELT_NAVN_FORESPOERSEL_ID to foresporselId.toJson(),
             )
         runCatching {
             kafkaProducer.send(

--- a/src/main/kotlin/no/nav/hag/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/hag/ForespoerselService.kt
@@ -8,6 +8,7 @@ import no.nav.hag.kafkaproducer.KafkaConfig.HENT_FORESPOERSLER_FOR_VEDTAKSPERIOD
 import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_BEHOV
 import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_FORESPOERSEL_ID
 import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_NOTIS
+import no.nav.hag.kafkaproducer.KafkaConfig.PRI_FELT_NAVN_VEDTAKSPERIODE_ID
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -64,7 +65,7 @@ class ForespoerselServiceImpl(
         val kafkaMessage =
             mapOf(
                 PRI_FELT_NAVN_BEHOV to HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID.toJson(),
-                PRI_FELT_NAVN_FORESPOERSEL_ID to vedtaksperiodeId.toJson(),
+                PRI_FELT_NAVN_VEDTAKSPERIODE_ID to vedtaksperiodeId.toJson(),
             )
         sendTilKafka(kafkaMessage, vedtaksperiodeId)
     }

--- a/src/main/kotlin/no/nav/hag/ForespoerselService.kt
+++ b/src/main/kotlin/no/nav/hag/ForespoerselService.kt
@@ -1,0 +1,68 @@
+package no.nav.hag
+
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+interface ForespoerselService {
+    suspend fun forkastForespoersel(
+        foresporselId: UUID,
+        brukernavn: String,
+    )
+}
+
+class ForespoerselServiceImpl(
+    kafkaProducer: KafkaProducer<String, String>,
+) : ForespoerselService {
+    private val logger = this::class.logger()
+    private val sikkerLogger = sikkerLogger()
+    private val kafkaProducer = kafkaProducer
+    private val topic = "helsearbeidsgiver.pri"
+
+    override suspend fun forkastForespoersel(
+        foresporselId: UUID,
+        brukernavn: String,
+    ) {
+        logger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
+        sikkerLogger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
+        val kafkaMessage =
+            mapOf(
+                "notis" to "FORESPOERSEL_MANUELT_FORKASTET".toJson(),
+                "forespoerselId" to foresporselId.toJson(),
+            )
+        runCatching {
+            kafkaProducer.send(
+                ProducerRecord(
+                    topic,
+                    foresporselId.toString(),
+                    kafkaMessage.toJsonStr(
+                        MapSerializer(String.serializer(), JsonElement.serializer()),
+                    ),
+                ),
+            )
+        }.onFailure { error ->
+            sikkerLogger.error("Feilet under sending til kafka", error)
+            logger.error("Feilet under sending til kafka")
+            throw error
+        }
+    }
+}
+
+class MockForespoerselService : ForespoerselService {
+    val logger = LoggerFactory.getLogger(FakeServiceImpl::class.java)
+
+    override suspend fun forkastForespoersel(
+        foresporselId: UUID,
+        brukernavn: String,
+    ) {
+        logger.info("Forkaster forespørsel: $foresporselId. Utført av $brukernavn")
+    }
+}

--- a/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
@@ -17,8 +17,11 @@ object KafkaConfig {
     fun getKafkaProducer(): KafkaProducer<String, String> = kafkaProducer
 
     const val PRI_FELT_NAVN_NOTIS = "notis"
+    const val PRI_FELT_NAVN_BEHOV = "@behov"
     const val PRI_FELT_NAVN_FORESPOERSEL_ID = "forespoerselId"
+    const val PRI_FELT_NAVN_VEDTAKSPERIODE_ID = "vedtaksperiode_id"
     const val FORESPOERSEL_MANUELT_FORKASTET = "FORESPOERSEL_MANUELT_FORKASTET"
+    const val HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID = "HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID"
 
     private fun createProducer(): KafkaProducer<String, String> =
         KafkaProducer(

--- a/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
@@ -16,6 +16,10 @@ object KafkaConfig {
 
     fun getKafkaProducer(): KafkaProducer<String, String> = kafkaProducer
 
+    const val PRI_FELT_NAVN_NOTIS = "notis"
+    const val PRI_FELT_NAVN_FORESPOERSEL_ID = "forespoerselId"
+    const val FORESPOERSEL_MANUELT_FORKASTET = "FORESPOERSEL_MANUELT_FORKASTET"
+
     private fun createProducer(): KafkaProducer<String, String> =
         KafkaProducer(
             kafkaProperties(),

--- a/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/hag/kafkaproducer/KafkaConfig.kt
@@ -1,0 +1,50 @@
+package no.nav.hag.kafkaproducer
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.serialization.StringSerializer
+
+object KafkaConfig {
+    private val kafkaProducer: KafkaProducer<String, String>
+
+    init {
+        kafkaProducer = createProducer()
+    }
+
+    fun getKafkaProducer(): KafkaProducer<String, String> = kafkaProducer
+
+    private fun createProducer(): KafkaProducer<String, String> =
+        KafkaProducer(
+            kafkaProperties(),
+            StringSerializer(),
+            StringSerializer(),
+        )
+
+    private fun kafkaProperties() =
+        mutableMapOf<String, Any>().apply {
+            val pkcs12 = "PKCS12"
+            val javaKeystore = "jks"
+
+            put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
+            put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
+            put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "15000")
+            put(ProducerConfig.RETRIES_CONFIG, "2")
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, System.getenv("KAFKA_BROKERS"))
+            put(ProducerConfig.ACKS_CONFIG, "all")
+            put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name)
+            put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "")
+            put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, javaKeystore)
+            put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, pkcs12)
+            put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, System.getenv("KAFKA_TRUSTSTORE_PATH"))
+            put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, System.getenv("KAFKA_CREDSTORE_PASSWORD"))
+            put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, System.getenv("KAFKA_KEYSTORE_PATH"))
+            put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, System.getenv("KAFKA_CREDSTORE_PASSWORD"))
+            put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, System.getenv("KAFKA_CREDSTORE_PASSWORD"))
+        }
+}

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -105,7 +105,7 @@ fun Application.configureRouting(
                             +" Tilhørende Sak og oppgave i Fager stenges. Spleis vil evt lage ny forespørsel ved behov."
                         }
                         p {
-                            a(href = "admin-ui/synkroniserForespoersel-form.html") {
+                            a(href = "admin-ui/synkroniserForespoersler-form.html") {
                                 +"Synkroniser forespørsler"
                             }
                             +" (Send inn vedtaksperiode(r) som er i usync i API - gjør synkronisering mellom StoreBror og LPS-API)"

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -30,12 +30,15 @@ import kotlinx.html.head
 import kotlinx.html.link
 import kotlinx.html.p
 import no.nav.hag.Env
+import no.nav.hag.ForespoerselService
 import no.nav.hag.NotifikasjonService
+import no.nav.hag.domain.ForespoerselListe
 import no.nav.hag.domain.NotifikasjonBatcher
 import no.nav.helsearbeidsgiver.utils.log.logger
 
 fun Application.configureRouting(
     notifikasjonService: NotifikasjonService,
+    forespoerselService: ForespoerselService,
     appMicrometerRegistry: PrometheusMeterRegistry,
 ) {
     routing {
@@ -165,6 +168,29 @@ fun Application.configureRouting(
                     val forespoerselBatch = NotifikasjonBatcher(notifikasjonService, brukernavn)
                     val rapport = forespoerselBatch.slettSaker(foresporselIdInput)
                     call.respond(HttpStatusCode.OK, rapport)
+                } catch (e: IllegalArgumentException) {
+                    call.respond(HttpStatusCode.BadRequest, "Ugyldig input: ${e.message}")
+                    return@post
+                } catch (ex: Exception) {
+                    call.respond(HttpStatusCode.InternalServerError, ex.message.toString())
+                }
+            }
+            post("/forkast") {
+                val skjema = call.receiveParameters()
+                val batch = skjema["foresporselIdInput"]
+                if (batch.isNullOrEmpty()) {
+                    call.respond(HttpStatusCode.BadRequest)
+                    return@post
+                }
+                try {
+                    // konverter og fjern de som ikke er OK UUIDer
+                    val foresporselIder = ForespoerselListe(batch).konverterInput().values.filterNotNull()
+
+                    for (foresporsel in foresporselIder) {
+                        forespoerselService.forkastForespoersel(foresporsel, hentBrukernavnFraToken())
+                    }
+
+                    call.respond(HttpStatusCode.OK, foresporselIder)
                 } catch (e: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest, "Ugyldig input: ${e.message}")
                     return@post

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -105,7 +105,7 @@ fun Application.configureRouting(
                             +" Tilhørende Sak og oppgave i Fager stenges. Spleis vil evt lage ny forespørsel ved behov."
                         }
                         p {
-                            a(href = "admin-ui/forkastForespoersel-form.html") {
+                            a(href = "admin-ui/synkroniserForespoersel-form.html") {
                                 +"Synkroniser forespørsler"
                             }
                             +" (Send inn vedtaksperiode(r) som er i usync i API - gjør synkronisering mellom StoreBror og LPS-API)"

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -197,7 +197,7 @@ fun Application.configureRouting(
                         forespoerselService.forkastForespoersel(foresporsel, hentBrukernavnFraToken())
                     }
 
-                    call.respond(HttpStatusCode.OK, foresporselIder)
+                    call.respond(HttpStatusCode.OK, foresporselIder.toString())
                 } catch (e: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest, "Ugyldig input: ${e.message}")
                     return@post

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -104,6 +104,12 @@ fun Application.configureRouting(
                             +" (Benytt eksponert ForespørselID - setter forespørsel til FORKASTET i StoreBror og LPS-API)"
                             +" Tilhørende Sak og oppgave i Fager stenges. Spleis vil evt lage ny forespørsel ved behov."
                         }
+                        p {
+                            a(href = "admin-ui/forkastForespoersel-form.html") {
+                                +"Synkroniser forespørsler"
+                            }
+                            +" (Send inn vedtaksperiode(r) som er i usync i API - gjør synkronisering mellom StoreBror og LPS-API)"
+                        }
                     }
                 }
             }
@@ -198,6 +204,29 @@ fun Application.configureRouting(
                     }
 
                     call.respond(HttpStatusCode.OK, foresporselIder.toString())
+                } catch (e: IllegalArgumentException) {
+                    call.respond(HttpStatusCode.BadRequest, "Ugyldig input: ${e.message}")
+                    return@post
+                } catch (ex: Exception) {
+                    call.respond(HttpStatusCode.InternalServerError, ex.message.toString())
+                }
+            }
+            post("/synkroniserForesporsler") {
+                val skjema = call.receiveParameters()
+                val batch = skjema["foresporselIdInput"]
+                if (batch.isNullOrEmpty()) {
+                    call.respond(HttpStatusCode.BadRequest)
+                    return@post
+                }
+                try {
+                    // konverter og fjern de som ikke er OK UUIDer
+                    val vedtaksperiodeIder = ForespoerselListe(batch).konverterInput().values.filterNotNull()
+
+                    for (vedtaksperiodeId in vedtaksperiodeIder) {
+                        forespoerselService.synkroniserForesporsler(vedtaksperiodeId, hentBrukernavnFraToken())
+                    }
+
+                    call.respond(HttpStatusCode.OK, vedtaksperiodeIder.toString())
                 } catch (e: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest, "Ugyldig input: ${e.message}")
                     return@post

--- a/src/main/kotlin/no/nav/hag/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/hag/plugins/Routing.kt
@@ -97,6 +97,13 @@ fun Application.configureRouting(
                             }
                             +" (Sletter hele saken - fjernes umiddelbart fra Min Side Arbeidsgiver-oversikt)"
                         }
+                        p {
+                            a(href = "admin-ui/forkastForespoersel-form.html") {
+                                +"Forkast forespørsler"
+                            }
+                            +" (Benytt eksponert ForespørselID - setter forespørsel til FORKASTET i StoreBror og LPS-API)"
+                            +" Tilhørende Sak og oppgave i Fager stenges. Spleis vil evt lage ny forespørsel ved behov."
+                        }
                     }
                 }
             }

--- a/src/main/resources/admin-ui/forkastForespoersel-form.html
+++ b/src/main/resources/admin-ui/forkastForespoersel-form.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/styles.css" type="text/css" />
 </head>
 <body>
-<h1>Finn saker</h1>
+<h1>Forkast forespørsel</h1>
 <form method="post" action="/forkast">
     <div>
         <label for="foresporselIdInput">ForespørselIder separert med ; (bruk eksponert forespørselId for å trigge lukking av sak og oppgave)</label>

--- a/src/main/resources/admin-ui/forkastForespoersel-form.html
+++ b/src/main/resources/admin-ui/forkastForespoersel-form.html
@@ -11,7 +11,7 @@
     <div>
         <label for="foresporselIdInput">ForespørselIder separert med ; (bruk eksponert forespørselId for å trigge lukking av sak og oppgave)</label>
     </div>
-    <textarea id="foresporselIdInput" name="foresporselIdInput" rows="100" cols="37" placeholder="UUID1;UUID2;..."></textarea>
+    <textarea id="foresporselIdInput" name="foresporselIdInput" rows="40" cols="37" placeholder="UUID1;UUID2;..."></textarea>
     <input type="submit">
 </form>
 </body>

--- a/src/main/resources/admin-ui/forkastForespoersel-form.html
+++ b/src/main/resources/admin-ui/forkastForespoersel-form.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forkast forespørsel</title>
+    <link rel="stylesheet" href="/styles.css" type="text/css" />
+</head>
+<body>
+<h1>Finn saker</h1>
+<form method="post" action="/forkast">
+    <div>
+        <label for="foresporselIdInput">ForespørselIder separert med ; (bruk eksponert forespørselId for å trigge lukking av sak og oppgave)</label>
+    </div>
+    <textarea id="foresporselIdInput" name="foresporselIdInput" rows="100" cols="37" placeholder="UUID1;UUID2;..."></textarea>
+    <input type="submit">
+</form>
+</body>
+</html>

--- a/src/main/resources/admin-ui/synkroniserForespoersler-form.html
+++ b/src/main/resources/admin-ui/synkroniserForespoersler-form.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/styles.css" type="text/css" />
 </head>
 <body>
-<h1>Finn saker</h1>
+<h1>Synkroniser forespørsler</h1>
 <form method="post" action="/synkroniserForesporsler">
     <div>
         <label for="foresporselIdInput">VedtaksperiodeIder separert med ;</label>

--- a/src/main/resources/admin-ui/synkroniserForespoersler-form.html
+++ b/src/main/resources/admin-ui/synkroniserForespoersler-form.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Synkroniser forespørsler</title>
+    <link rel="stylesheet" href="/styles.css" type="text/css" />
+</head>
+<body>
+<h1>Finn saker</h1>
+<form method="post" action="/synkroniserForesporsler">
+    <div>
+        <label for="foresporselIdInput">VedtaksperiodeIder separert med ;</label>
+    </div>
+    <textarea id="foresporselIdInput" name="foresporselIdInput" rows="40" cols="37" placeholder="UUID1;UUID2;..."></textarea>
+    <input type="submit">
+</form>
+</body>
+</html>

--- a/src/test/kotlin/no/nav/hag/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/hag/ApplicationTest.kt
@@ -39,7 +39,7 @@ class ApplicationTest {
 
             application {
                 configureSecurity(authClient, disabled = false)
-                configureRouting(FakeServiceImpl(), appMicrometerRegistry)
+                configureRouting(FakeServiceImpl(), MockForespoerselService(), appMicrometerRegistry)
             }
 
             client


### PR DESCRIPTION
Nytt skjema og kode for å forkaste aktive forespørsler i Bro. 
Dette kafka-kallet trigger en ny river i Bro, som søker opp og lukker forespørsel og deretter propagerer en standard FORESPOERSEL_FORKASTET på pri-topic (plukkes opp av Simba og LPS-API)


(Bro gjør også et synk-kall på tilhørende vedtaksperiodeId, slik at LPS-API oppdaterer alle tilhørende forespørsler, dette er nødvendig fordi man i utgangspunkt ber om at eksponert_forespørsel_id skal forkastes (slik at sak og oppgave også lukkes). 
Der man har flere fsp i en vedtaksperiode, vil bro lukke den som er AKTIV (eksponert er da tidligere forkastet allerede). 
Den som lukkes, propageres ikke videre, kun eksponert id. 
Derfor gjøres det en synk, slik at LPS-API også får med seg lukking av den aktive. )

Legger også til mulighet for å bare gjøre synkronisering - dette var tidligere mulig kun med hjemmesnekret kafka-kall, nå kan det også utføres i admin-gui.